### PR TITLE
[SVP-14010] Fix: Ansible - Using a password with special characters fail a instalation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,9 +66,9 @@
     set timeout 10
     spawn vprotect-server-configure
     expect "Set MySQL root password: "
-    send "{{ db_pass | quote }}\n"
+    send "{{ db_pass }}\n"
     expect "Type password again: "
-    send "{{ db_pass | quote }}\n"
+    send "{{ db_pass }}\n"
     expect eof
     exit 0
   args:


### PR DESCRIPTION
Removed 'quote' from 'Configure the Server' task